### PR TITLE
feat(memorystar): Public 게시물 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/startlight/global/response/PageResponse.java
+++ b/src/main/java/com/example/startlight/global/response/PageResponse.java
@@ -1,4 +1,4 @@
-package com.example.startlight.memory.memComment.dto;
+package com.example.startlight.global.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/startlight/infra/kakao/KakaoOauthController.java
+++ b/src/main/java/com/example/startlight/infra/kakao/KakaoOauthController.java
@@ -42,18 +42,13 @@ public class KakaoOauthController{
         try {
             // 1. Access Token 가져오기
             String accessToken = kakaoService.getAccessTokenFromKakao(code);
-            log.info("accessToken: {}", accessToken);
 
             // 2. 사용자 정보 가져오기
             KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
-            log.info("Kakao User Info: {}", userInfo);
 
             // 3. JWT 생성
             boolean rememberMe = "true".equals(request.getParameter("rememberMe"));
             JWTUtils.TokenDto tokens = jwtTokenProvider.createTokens(userInfo, accessToken, rememberMe);
-
-            log.info("Generated Access Token: {}", tokens.getAccessToken());
-            log.info("Generated Refresh Token: {}", tokens.getRefreshToken());
 
             // 4. 인증 객체 확인
             Authentication authentication = jwtTokenProvider.verifyAndGetAuthentication(tokens.getAccessToken());
@@ -73,6 +68,8 @@ public class KakaoOauthController{
                     .sameSite(sameSiteValue)
                     .build();
 
+            System.out.println("AUTH-TOKEN : "+tokens.getAccessToken());
+
             // 6. Refresh Token을 쿠키에 저장
             final ResponseCookie refreshTokenCookie = ResponseCookie.from("REFRESH-TOKEN", tokens.getRefreshToken())
                     .httpOnly(true)
@@ -81,6 +78,8 @@ public class KakaoOauthController{
                     .secure(isSecure)
                     .sameSite(sameSiteValue)
                     .build();
+
+            System.out.println("REFRESH-TOKEN : "+tokens.getRefreshToken());
 
             response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
             response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());

--- a/src/main/java/com/example/startlight/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/startlight/member/repository/MemberRepository.java
@@ -8,4 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("select m.profile_img from Member m where m.member_id =:memberId")
+    String getProfileImgUrl(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/example/startlight/memory/memComment/controller/MemCommentController.java
+++ b/src/main/java/com/example/startlight/memory/memComment/controller/MemCommentController.java
@@ -4,7 +4,7 @@ import com.example.startlight.likes.service.LikesService;
 import com.example.startlight.memory.memComment.dto.MemCommentRepDto;
 import com.example.startlight.memory.memComment.dto.MemCommentReqDto;
 import com.example.startlight.memory.memComment.dto.MemCommentUpdateReqDto;
-import com.example.startlight.memory.memComment.dto.PageResponse;
+import com.example.startlight.global.response.PageResponse;
 import com.example.startlight.memory.memComment.service.MemCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/startlight/memory/memComment/repository/MemCommentRepository.java
+++ b/src/main/java/com/example/startlight/memory/memComment/repository/MemCommentRepository.java
@@ -14,6 +14,9 @@ public interface MemCommentRepository extends JpaRepository<MemComment, Long> {
     @Query("SELECT mc from MemComment mc where mc.memoryStar.memory_id = :memoryId ORDER BY mc.comment_id DESC")
     List<MemComment> findAllByMemoryIdDesc(@Param("memoryId") Long memory_id);
 
+    @Query("select count(mc) from MemComment mc where mc.memoryStar.memory_id = :memoryId")
+    Integer countByMemoryId(@Param("memoryId") Long memoryId);
+
     @Query(
             value = "select mc " +
                     "from MemComment mc " +

--- a/src/main/java/com/example/startlight/memory/memComment/service/MemCommentService.java
+++ b/src/main/java/com/example/startlight/memory/memComment/service/MemCommentService.java
@@ -6,7 +6,7 @@ import com.example.startlight.memory.memComment.dao.MemCommentDao;
 import com.example.startlight.memory.memComment.dto.MemCommentRepDto;
 import com.example.startlight.memory.memComment.dto.MemCommentReqDto;
 import com.example.startlight.memory.memComment.dto.MemCommentUpdateReqDto;
-import com.example.startlight.memory.memComment.dto.PageResponse;
+import com.example.startlight.global.response.PageResponse;
 import com.example.startlight.memory.memComment.entity.MemComment;
 import com.example.startlight.memory.memComment.mapper.MemCommentMapper;
 import com.example.startlight.member.dao.MemberDao;

--- a/src/main/java/com/example/startlight/memory/memoryStar/controller/MemoryStarController.java
+++ b/src/main/java/com/example/startlight/memory/memoryStar/controller/MemoryStarController.java
@@ -1,20 +1,20 @@
 package com.example.startlight.memory.memoryStar.controller;
 
-import com.example.startlight.memory.memoryStar.dto.MemoryStarRepDto;
-import com.example.startlight.memory.memoryStar.dto.MemoryStarRepWithComDto;
-import com.example.startlight.memory.memoryStar.dto.MemoryStarReqDto;
-import com.example.startlight.memory.memoryStar.dto.MemoryStarUpdateDto;
+import com.example.startlight.global.response.PageResponse;
+import com.example.startlight.memory.memoryStar.dto.*;
 import com.example.startlight.memory.memoryStar.service.MemoryStarLikeService;
 import com.example.startlight.memory.memoryStar.service.MemoryStarQueryService;
 import com.example.startlight.memory.memoryStar.service.MemoryStarService;
 import com.example.startlight.memory.starReaction.entity.ReactionType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -56,11 +56,14 @@ public class MemoryStarController {
         return ResponseEntity.status(HttpStatus.OK).body("Success delete memory star id : " + memoryId);
     }
 
-//    @GetMapping("/public")
-//    public ResponseEntity<List<MemoryStarSimpleRepDto>> getAllMemoryStar() {
-//        List<MemoryStarSimpleRepDto> allPublicMemoryStar = memoryStarService.findAllPublicMemoryStar();
-//        return ResponseEntity.status(HttpStatus.OK).body(allPublicMemoryStar);
-//    }
+    @GetMapping("/public")
+    public ResponseEntity<PageResponse<MemoryStarPublicRepDto>> getPublicStars(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        PageResponse<MemoryStarPublicRepDto> stars = memoryStarQueryService.getPublicStars(page, size);
+        return ResponseEntity.ok(stars);
+    }
 //
 //    @GetMapping()
 //    public ResponseEntity<MemoryStarListWithNumDto> getMyMemoryStar() {

--- a/src/main/java/com/example/startlight/memory/memoryStar/dao/MemoryStarDao.java
+++ b/src/main/java/com/example/startlight/memory/memoryStar/dao/MemoryStarDao.java
@@ -55,10 +55,6 @@ public class MemoryStarDao {
         }
     }
 
-    public List<MemoryStar> getAllPublicMemoryStar() {
-        return memoryStarRepository.findBySharedTrue();
-    }
-
     public List<MemoryStar> getAllMyMemoryStar(Long userId) {
         return memoryStarRepository.findAllByWriterId(userId);
     }

--- a/src/main/java/com/example/startlight/memory/memoryStar/dto/MemoryStarPublicRepDto.java
+++ b/src/main/java/com/example/startlight/memory/memoryStar/dto/MemoryStarPublicRepDto.java
@@ -1,0 +1,20 @@
+package com.example.startlight.memory.memoryStar.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record MemoryStarPublicRepDto(
+        Long memoryId,
+        String profileImgUrl,
+        String writerName,
+        String name,
+        String content,
+        Map<String, ReactionDto> reactions,
+        Integer commentNumber,
+        String imgUrl,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime updatedAt
+        ) {
+}

--- a/src/main/java/com/example/startlight/memory/memoryStar/repository/MemoryStarRepository.java
+++ b/src/main/java/com/example/startlight/memory/memoryStar/repository/MemoryStarRepository.java
@@ -1,6 +1,8 @@
 package com.example.startlight.memory.memoryStar.repository;
 
 import com.example.startlight.memory.memoryStar.entity.MemoryStar;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,9 +10,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MemoryStarRepository extends JpaRepository<MemoryStar, Long> {
-
-    @Query("select m from MemoryStar m where m.shared = true order by m.memory_id desc")
-    List<MemoryStar> findBySharedTrue();
 
     @Query("select m from MemoryStar m where m.writer_id = :userId order by m.memory_id desc")
     List<MemoryStar> findAllByWriterId(@Param("userId") Long userId);
@@ -26,4 +25,7 @@ public interface MemoryStarRepository extends JpaRepository<MemoryStar, Long> {
 
     @Query("SELECT count(m) FROM MemoryStar m WHERE m.pet_id = :petId")
     Integer countMemoryStarByPetId(@Param("petId") Long petId);
+
+    @Query("select m from MemoryStar m where m.shared = true order by m.updatedAt desc")
+    Page<MemoryStar> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/startlight/memory/memoryStar/service/MemoryStarQueryService.java
+++ b/src/main/java/com/example/startlight/memory/memoryStar/service/MemoryStarQueryService.java
@@ -1,16 +1,25 @@
 package com.example.startlight.memory.memoryStar.service;
 
+import com.example.startlight.global.response.PageResponse;
 import com.example.startlight.infra.kakao.util.UserUtil;
+import com.example.startlight.member.repository.MemberRepository;
+import com.example.startlight.memory.memComment.repository.MemCommentRepository;
 import com.example.startlight.memory.memoryStar.dao.MemoryStarDao;
+import com.example.startlight.memory.memoryStar.dto.MemoryStarPublicRepDto;
 import com.example.startlight.memory.memoryStar.dto.MemoryStarRepDto;
 import com.example.startlight.memory.memoryStar.dto.ReactionDto;
 import com.example.startlight.memory.memoryStar.entity.MemoryStar;
 import com.example.startlight.memory.memoryStar.mapper.MemoryStarMapper;
+import com.example.startlight.memory.memoryStar.repository.MemoryStarRepository;
 import com.example.startlight.memory.starReaction.entity.ReactionType;
 import com.example.startlight.memory.starReaction.entity.StarReaction;
 import com.example.startlight.memory.starReaction.repository.StarReactionRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.LinkedHashMap;
@@ -26,39 +35,109 @@ public class MemoryStarQueryService {
     private final MemoryStarDao memoryStarDao;
     private final MemoryStarMapper mapper = MemoryStarMapper.INSTANCE;
     private final StarReactionRepository starReactionRepository;
+    private final MemoryStarRepository memoryStarRepository;
+    private final MemCommentRepository memCommentRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public MemoryStarRepDto getStarById(Long id) {
         MemoryStar memoryStar = memoryStarDao.selectMemoryStarById(id);
         Long userId = UserUtil.getCurrentUserId();
 
-        List<StarReaction> myReactions =
-                starReactionRepository.findByMemoryIdAndMemberId(memoryStar.getMemory_id(), userId);
-
-        Set<ReactionType> myTypes = myReactions.stream()
-                .map(StarReaction::getReactionType)
-                .collect(Collectors.toSet());
-
-        Map<String, ReactionDto> reactions = new LinkedHashMap<>();
-        Integer totalLikes = 0;
-
-        for (ReactionType type : ReactionType.values()) {
-            Integer count = getCountForType(type, memoryStar);
-            boolean isLiked = myTypes.contains(type);
-
-            reactions.put(
-                    type.name(),
-                    new ReactionDto(type.name(), count, isLiked)
-            );
-            totalLikes += count;
-        }
+        // reactions 조회 로직 분리
+        ReactionsInfo reactionsInfo = buildReactionsInfo(memoryStar, userId);
 
         MemoryStarRepDto dto = mapper.toDto(memoryStar);
-        dto.setReactions(reactions);
-        dto.setTotalLikes(totalLikes);
+        dto.setReactions(reactionsInfo.reactions());
+        dto.setTotalLikes(reactionsInfo.totalLikes());
         return dto;
     }
 
+    /**
+     * Public 게시물 목록 조회
+     */
+    @Transactional
+    public PageResponse<MemoryStarPublicRepDto> getPublicStars(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<MemoryStar> stars = memoryStarRepository.findByIsPublicTrueOrderByCreatedAtDesc(pageable);
+
+        Long userId = UserUtil.getCurrentUserId();
+
+        // DTO 변환
+        Page<MemoryStarPublicRepDto> dtoPage = stars.map(star -> toPublicRepDto(star, userId));
+
+        return new PageResponse<>(
+                dtoPage.getContent(),
+                dtoPage.isLast(),
+                dtoPage.getTotalElements(),
+                dtoPage.getTotalPages(),
+                dtoPage.isFirst(),
+                dtoPage.getSize(),
+                dtoPage.getNumber(),
+                dtoPage.getNumberOfElements(),
+                dtoPage.isEmpty()
+        );
+    }
+
+    /**
+     * Entity -> Public DTO 변환
+     */
+    private MemoryStarPublicRepDto toPublicRepDto(MemoryStar star, Long userId) {
+        // 반응 정보 조회
+        ReactionsInfo reactionsInfo = buildReactionsInfo(star, userId);
+
+        // 댓글 수 조회
+        Integer commentCount = memCommentRepository.countByMemoryId(star.getMemory_id());
+        String profileUrl = memberRepository.getProfileImgUrl(star.getWriter_id());
+
+        return new MemoryStarPublicRepDto(
+                star.getMemory_id(),
+                profileUrl,
+                star.getWriter_name(),
+                star.getName(),
+                star.getContent(),
+                reactionsInfo.reactions(),
+                commentCount,
+                star.getImg_url(),
+                star.getUpdatedAt()
+        );
+    }
+
+    /**
+     * 반응 정보 조회 및 구성
+     */
+    private ReactionsInfo buildReactionsInfo(MemoryStar memoryStar, Long userId) {
+        Set<ReactionType> myReactionTypes = getMyReactionTypes(memoryStar.getMemory_id(), userId);
+
+        Map<String, ReactionDto> reactions = new LinkedHashMap<>();
+        int totalLikes = 0;
+
+        for (ReactionType type : ReactionType.values()) {
+            Integer count = getCountForType(type, memoryStar);
+            boolean isLiked = myReactionTypes.contains(type);
+
+            reactions.put(type.name(), new ReactionDto(type.name(), count, isLiked));
+            totalLikes += count;
+        }
+
+        return new ReactionsInfo(reactions, totalLikes);
+    }
+
+    /**
+     * 사용자가 누른 반응 타입 조회
+     */
+    private Set<ReactionType> getMyReactionTypes(Long memoryId, Long userId) {
+        List<StarReaction> myReactions =
+                starReactionRepository.findByMemoryIdAndMemberId(memoryId, userId);
+
+        return myReactions.stream()
+                .map(StarReaction::getReactionType)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 반응 타입별 카운트 조회
+     */
     private Integer getCountForType(ReactionType type, MemoryStar star) {
         return switch (type) {
             case LIKE1 -> star.getLike1();
@@ -66,4 +145,12 @@ public class MemoryStarQueryService {
             case LIKE3 -> star.getLike3();
         };
     }
+
+    /**
+     * 반응 정보를 담는 내부 record
+     */
+    private record ReactionsInfo(
+            Map<String, ReactionDto> reactions,
+            Integer totalLikes
+    ) {}
 }

--- a/src/main/java/com/example/startlight/memory/memoryStar/service/MemoryStarService.java
+++ b/src/main/java/com/example/startlight/memory/memoryStar/service/MemoryStarService.java
@@ -1,6 +1,7 @@
 package com.example.startlight.memory.memoryStar.service;
 
 import com.example.startlight.infra.kakao.util.UserUtil;
+import com.example.startlight.member.repository.MemberRepository;
 import com.example.startlight.memory.memComment.dto.MemCommentRepDto;
 import com.example.startlight.memory.memComment.service.MemCommentService;
 import com.example.startlight.member.dao.MemberDao;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -32,6 +34,7 @@ public class MemoryStarService {
     private final S3Service s3Service;
     private final MemoryStarMapper mapper = MemoryStarMapper.INSTANCE;
     private final StarReactionRepository starReactionRepository;
+    private final MemberRepository memberRepository;
 
     public MemoryStarRepDto createMemoryStar(MemoryStarReqDto memoryStarReqDto) throws IOException {
         Long userId = UserUtil.getCurrentUserId();
@@ -67,11 +70,6 @@ public class MemoryStarService {
         MemoryStar memoryStar = memoryStarDao.selectMemoryStarById(memoryId);
         memoryStarDao.deleteMemoryStarById(userId, memoryStar);
         s3Service.deleteMemoryImg(memoryId);
-    }
-
-    public List<MemoryStarSimpleRepDto> findAllPublicMemoryStar() {
-        List<MemoryStar> allPublicMemoryStar = memoryStarDao.getAllPublicMemoryStar();
-        return mapper.toSimpleRepDtoList(allPublicMemoryStar);
     }
 
     public List<MemoryStarSimpleRepDto> findAllMyMemoryStar() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈


## #️⃣ 작업 내용

- 5.1.1 공개된 전체 추억별 조회 API 개발 완료
## #️⃣ 주요 변경 사항
- **Public MemoryStar 조회 기능 추가**
  - 최신순 페이징 조회 엔드포인트 추가 (`GET /api/memory-stars/public`)
  - `page`, `size` 파라미터 지원

- **Service**
  - `getPublicStars` 메서드 추가
  - Entity → `MemoryStarPublicRepDto` 변환 로직 분리
  - 기존 `buildReactionsInfo` 로직 재사용

- **Repository**
  - `findByIsPublicTrueOrderByCreatedAtDesc` 쿼리 추가
  - `@EntityGraph` 적용으로 작성자 정보 fetch join (N+1 방지)
  - 댓글 수 조회용 `countByMemoryId` 메서드 추가

- **DTO / Response**
  - `MemoryStarPublicRepDto` 신규 정의
  - 작성자 정보, 프로필 이미지, 반응 정보, 댓글 수 포함
  - 공통 `PageResponse` 응답 포맷 사용

## #️⃣ 테스트 결과

> API 5.1.1 테스트 완료

## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [X] 문서를 작성하거나 수정했나요? (필요한 경우)
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?